### PR TITLE
リセットスクリプトの追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(git add:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 # 環境依存のローカル設定ファイル
 zsh/local.zsh
-.claude

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # 環境依存のローカル設定ファイル
 zsh/local.zsh
+.claude

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ dotfiles/
 ├── .gitignore
 ├── README.md
 ├── setup.sh               # セットアップスクリプト
+├── reset.sh               # リセット/アンインストールスクリプト
 └── zsh/
     ├── common.zsh         # Oh My Zshの基本設定
     ├── plugins.zsh        # プラグイン固有の設定（fzf, autosuggestions等）
@@ -237,6 +238,69 @@ alias gs='git status'
 **注意**:
 - `setup.sh`はOSを自動検出し、macOS以外では一部機能（Nerd Fonts自動インストール）をスキップします
 - 既存の設定ファイルは自動的にバックアップされるため、安全に実行できます
+
+## 設定のリセット・アンインストール
+
+`setup.sh`で設定した内容を削除し、元の環境に戻したい場合は、`reset.sh`スクリプトを使用します。
+
+### リセットスクリプトの実行
+
+```bash
+chmod +x reset.sh
+./reset.sh
+```
+
+### リセット内容
+
+スクリプトは以下の項目を**インタラクティブに**確認しながら削除・復元します：
+
+#### 自動実行される項目
+- **~/.zshrcの復元**: バックアップファイルから最新のものを自動復元
+  - 複数のバックアップがある場合、古いものの削除も選択可能
+
+#### 確認される項目
+- **local.zshの削除**: 環境固有設定ファイルを削除するか確認
+- **Zshプラグインの削除**: zsh-autosuggestions、zsh-syntax-highlightingを削除するか確認
+- **Oh My Zshのアンインストール**: Oh My Zsh本体を削除するか確認
+  - 公式アンインストールスクリプトを使用
+  - カスタムテーマやプラグインも削除されます
+- **fzfのアンインストール** (macOSのみ): Homebrewでインストールしたfzfを削除するか確認
+  - `~/.fzf.zsh`などの設定ファイルも削除
+- **Nerd Fontsのアンインストール** (macOSのみ): Meslo Nerd Fontを削除するか確認
+- **~/.zprofileのクリーンアップ** (Apple Siliconのみ): Homebrewのパス設定を削除するか確認
+
+### 注意事項
+
+- バックアップファイルが見つからない場合は警告が表示されます
+- 各項目は個別に選択できるため、必要な部分だけリセット可能です
+- Oh My Zshをアンインストールすると、他のカスタマイズも削除される可能性があります
+- Nerd Fontsをアンインストールした場合、ターミナルのフォント設定を元に戻す必要があります
+
+### 手動でリセットする場合
+
+スクリプトを使用せずに手動でリセットする場合：
+
+```bash
+# 1. ~/.zshrcをバックアップから復元
+mv ~/.zshrc.backup.YYYYMMDD_HHMMSS ~/.zshrc
+
+# 2. Zshプラグインを削除
+rm -rf ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+rm -rf ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+
+# 3. Oh My Zshをアンインストール（オプション）
+~/.oh-my-zsh/tools/uninstall.sh
+
+# 4. fzfをアンインストール（macOS、オプション）
+brew uninstall fzf
+rm -f ~/.fzf.zsh ~/.fzf.bash
+
+# 5. Nerd Fontsをアンインストール（macOS、オプション）
+brew uninstall --cask font-meslo-lg-nerd-font
+
+# 6. local.zshを削除
+rm -f <クローンしたディレクトリ>/zsh/local.zsh
+```
 
 ## トラブルシューティング
 

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+
+# ===================================
+# Dotfiles リセットスクリプト
+# ===================================
+# このスクリプトは、setup.shで設定した内容を削除し、
+# バックアップから元の状態に復元します。
+#
+# 使い方:
+#   chmod +x reset.sh
+#   ./reset.sh
+# ===================================
+
+set -euo pipefail
+
+# 色付きの出力用
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# dotfilesリポジトリのディレクトリ（このスクリプトがあるディレクトリを自動検出）
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ログ出力関数
+info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# バックアップから復元する関数
+restore_from_backup() {
+    local file=$1
+
+    # 最新のバックアップファイルを検索
+    local latest_backup=$(ls -t "${file}.backup."* 2>/dev/null | head -n 1)
+
+    if [ -n "$latest_backup" ]; then
+        info "バックアップから復元しています: $latest_backup"
+        mv "$latest_backup" "$file"
+        success "復元が完了しました: $file"
+
+        # 他のバックアップファイルを削除するか確認
+        local other_backups=$(ls -t "${file}.backup."* 2>/dev/null | tail -n +2)
+        if [ -n "$other_backups" ]; then
+            echo ""
+            read -r -p "他のバックアップファイルも削除しますか? (y/n) " response
+            if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+                echo "$other_backups" | xargs rm -f
+                success "他のバックアップファイルを削除しました"
+            fi
+        fi
+    else
+        warning "バックアップファイルが見つかりませんでした: ${file}.backup.*"
+    fi
+}
+
+echo ""
+echo "=========================================="
+echo "  Dotfiles リセットを開始します"
+echo "=========================================="
+echo ""
+warning "この操作により、setup.shで設定した内容が削除されます"
+warning "バックアップがある場合は、そこから復元されます"
+echo ""
+read -r -p "本当にリセットしますか? (y/n) " response
+if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    info "リセットをキャンセルしました"
+    exit 0
+fi
+echo ""
+
+# 1. ~/.zshrcの復元
+info "~/.zshrcを復元中..."
+if [ -f "$HOME/.zshrc" ]; then
+    # 現在の.zshrcを削除
+    rm -f "$HOME/.zshrc"
+    success "現在の~/.zshrcを削除しました"
+
+    # バックアップから復元
+    restore_from_backup "$HOME/.zshrc"
+else
+    warning "~/.zshrcが存在しません"
+fi
+echo ""
+
+# 2. local.zshの削除
+info "local.zshの削除を確認中..."
+if [ -f "$DOTFILES_DIR/zsh/local.zsh" ]; then
+    read -r -p "local.zshを削除しますか? (y/n) " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+        rm -f "$DOTFILES_DIR/zsh/local.zsh"
+        success "local.zshを削除しました"
+    else
+        info "local.zshの削除をスキップしました"
+    fi
+else
+    info "local.zshが存在しません"
+fi
+echo ""
+
+# 3. Zshプラグインの削除
+info "Zshプラグインの削除を確認中..."
+read -r -p "Zshプラグイン(zsh-autosuggestions, zsh-syntax-highlighting)を削除しますか? (y/n) " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    # zsh-autosuggestions
+    if [ -d "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" ]; then
+        rm -rf "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+        success "zsh-autosuggestionsを削除しました"
+    else
+        info "zsh-autosuggestionsが存在しません"
+    fi
+
+    # zsh-syntax-highlighting
+    if [ -d "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" ]; then
+        rm -rf "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
+        success "zsh-syntax-highlightingを削除しました"
+    else
+        info "zsh-syntax-highlightingが存在しません"
+    fi
+else
+    info "Zshプラグインの削除をスキップしました"
+fi
+echo ""
+
+# 4. Oh My Zshのアンインストール
+info "Oh My Zshのアンインストールを確認中..."
+if [ -d "$HOME/.oh-my-zsh" ]; then
+    echo ""
+    warning "注意: Oh My Zshをアンインストールすると、カスタムテーマやプラグインも削除されます"
+    read -r -p "Oh My Zshをアンインストールしますか? (y/n) " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+        info "Oh My Zshをアンインストールしています..."
+        # Oh My Zshの公式アンインストールスクリプトを使用
+        if [ -f "$HOME/.oh-my-zsh/tools/uninstall.sh" ]; then
+            env ZSH="$HOME/.oh-my-zsh" sh "$HOME/.oh-my-zsh/tools/uninstall.sh" || true
+            success "Oh My Zshのアンインストールが完了しました"
+        else
+            # 手動で削除
+            rm -rf "$HOME/.oh-my-zsh"
+            success "Oh My Zshのディレクトリを削除しました"
+        fi
+    else
+        info "Oh My Zshのアンインストールをスキップしました"
+    fi
+else
+    info "Oh My Zshが存在しません"
+fi
+echo ""
+
+# 5. fzfのアンインストール (macOSのみ)
+OS_TYPE="$(uname -s)"
+if [[ "$OS_TYPE" == "Darwin" ]] && command -v brew &> /dev/null; then
+    info "fzfのアンインストールを確認中..."
+    if command -v fzf &> /dev/null; then
+        read -r -p "fzfをアンインストールしますか? (y/n) " response
+        if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+            info "fzfをアンインストールしています..."
+            brew uninstall fzf || true
+
+            # fzf設定ファイルの削除
+            if [ -f "$HOME/.fzf.zsh" ]; then
+                rm -f "$HOME/.fzf.zsh"
+                success "~/.fzf.zshを削除しました"
+            fi
+            if [ -f "$HOME/.fzf.bash" ]; then
+                rm -f "$HOME/.fzf.bash"
+                success "~/.fzf.bashを削除しました"
+            fi
+
+            success "fzfのアンインストールが完了しました"
+        else
+            info "fzfのアンインストールをスキップしました"
+        fi
+    else
+        info "fzfはインストールされていません"
+    fi
+    echo ""
+
+    # 6. Nerd Fontsのアンインストール (macOSのみ)
+    info "Nerd Fontsのアンインストールを確認中..."
+    if brew list --cask font-meslo-lg-nerd-font &> /dev/null; then
+        read -r -p "Meslo Nerd Fontをアンインストールしますか? (y/n) " response
+        if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+            info "Meslo Nerd Fontをアンインストールしています..."
+            brew uninstall --cask font-meslo-lg-nerd-font || true
+            success "Meslo Nerd Fontのアンインストールが完了しました"
+            warning "ターミナルアプリのフォント設定を元に戻してください"
+        else
+            info "Meslo Nerd Fontのアンインストールをスキップしました"
+        fi
+    else
+        info "Meslo Nerd Fontはインストールされていません"
+    fi
+    echo ""
+fi
+
+# 7. .zprofileの復元（Apple Siliconの場合、Homebrewのパス設定が追加されている可能性がある）
+if [[ "$OS_TYPE" == "Darwin" ]] && [[ $(uname -m) == "arm64" ]]; then
+    info "~/.zprofileの確認..."
+    if [ -f "$HOME/.zprofile" ]; then
+        if grep -q "/opt/homebrew/bin/brew shellenv" "$HOME/.zprofile"; then
+            echo ""
+            warning "~/.zprofileにHomebrewのパス設定が含まれています"
+            info "以下の行が見つかりました:"
+            grep "/opt/homebrew/bin/brew shellenv" "$HOME/.zprofile"
+            echo ""
+            read -r -p "この設定を削除しますか? (y/n) " response
+            if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+                # バックアップを作成
+                cp "$HOME/.zprofile" "$HOME/.zprofile.backup.$(date +%Y%m%d_%H%M%S)"
+                # Homebrewの設定行を削除
+                sed -i.tmp '/\/opt\/homebrew\/bin\/brew shellenv/d' "$HOME/.zprofile"
+                rm -f "$HOME/.zprofile.tmp"
+                success "~/.zprofileからHomebrewのパス設定を削除しました"
+            else
+                info "~/.zprofileの変更をスキップしました"
+            fi
+        fi
+    fi
+    echo ""
+fi
+
+# 8. 完了メッセージ
+echo ""
+echo "=========================================="
+echo "  リセットが完了しました！"
+echo "=========================================="
+echo ""
+success "dotfilesの設定がリセットされました"
+echo ""
+info "次のステップ:"
+echo "  1. 新しいターミナルを開いて、設定が元に戻っていることを確認してください"
+echo "  2. 必要に応じて、手動で追加の設定を確認してください"
+echo ""


### PR DESCRIPTION
## 概要
setup.shで設定した内容を元に戻すためのリセットスクリプトを追加しました。

## 変更内容
- **reset.shの作成**: インタラクティブなアンインストールスクリプト
  - バックアップから.zshrcを復元
  - Oh My Zsh、プラグイン、fzf、Nerd Fontsの削除に対応
  - Apple Siliconでの.zprofileクリーンアップに対応
- **READMEの更新**: リセット/アンインストール手順のドキュメント追加

## テスト方法
- [ ] reset.shに実行権限が付与されていることを確認
- [ ] スクリプトを実行して各プロンプトが正しく動作することを確認
- [ ] バックアップからの復元が正常に動作することを確認
- [ ] 各項目の選択的な削除が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)